### PR TITLE
[BUG] A writer MUST include "c" but not in examples

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -177,7 +177,7 @@ A writer:
   - MAY include one `x` field.
     - if `x` is included:
       - SHOULD use the minimum `data_length` possible.
-  - MUST include one `c` field (`min_final_cltv_expiry_delta`).
+  - MAY include one `c` field (`min_final_cltv_expiry_delta`).
     - MUST set `c` to the minimum `cltv_expiry` it will accept for the last
     HTLC in the route.
     - SHOULD use the minimum `data_length` possible.


### PR DESCRIPTION
If the requirement is that a writer MUST include `c`, how come that the examples not all have `c`?

should there be a `c` in the examples? 
or is it really a MAY?

am i misunderstanding something?
thanks for the review.